### PR TITLE
Enable server name validation

### DIFF
--- a/EduroamConfigure/ProfileXml.cs
+++ b/EduroamConfigure/ProfileXml.cs
@@ -238,7 +238,7 @@ namespace EduroamConfigure
 							),
 							new XElement(nsETCPv1 + "DifferentUsername", "false"),
 							new XElement(nsETCPv2 + "PerformServerValidation", "true"),
-							new XElement(nsETCPv2 + "AcceptServerName", "false"),
+							new XElement(nsETCPv2 + "AcceptServerName", serverNames.Any() ? "true" : "false"),
 							new XElement(nsETCPv2 + "TLSExtensions",
 								new XElement(nsETCPv3 + "FilteringInfo",
 									caHashListElement =


### PR DESCRIPTION
Currently `AcceptServerName` is always `false` which does not validate the server's name against `ServerNames` (which is already set). If a public CA is configured, an attacker could simply obtain a certificate obtained by the same CA and spoof the RADIUS server. The client would trust this server since it only validates that the certificate was issued by an allowed CA, NOT the server name.


This PR changes `AcceptServerName` to be `true` when at least one server name is given.


https://learn.microsoft.com/en-us/windows/win32/eaphost/eaptlsconnectionpropertiesv1schema-tlsextensionstype-peapextensionstype-element