### PR TITLE
Make the MainWindow a ToolWindow

### DIFF
--- a/App.Library/AppWindowChrome.xaml
+++ b/App.Library/AppWindowChrome.xaml
@@ -25,14 +25,14 @@
                         </Border>
 
                         <Grid x:Name="TitleBar" 
-                              Margin="10, 1, 148, 0" Height="24" 
+                              Margin="10, 1, 32, 0" Height="19"
                               HorizontalAlignment="Stretch" 
                               VerticalAlignment="Top"
                               Background="{DynamicResource BackgroundBrush}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="24" />
                                 <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="40" />
+                                <ColumnDefinition Width="19" />
                             </Grid.ColumnDefinitions>
 
                             <Button Grid.Column="0" 

--- a/App.Library/MainWindow.xaml
+++ b/App.Library/MainWindow.xaml
@@ -19,7 +19,10 @@
     MinWidth="420"
     MinHeight="420"
     Closing="MainWindow_OnClosing"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    WindowStartupLocation="CenterScreen"
+    WindowStyle="ToolWindow"
+    SizeToContent="Width">
 
     <Window.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
When maximizing the main window, there's a lot of white space. By switching to a tool window, we discourage users from making the window too big.