### PR TITLE
Cleanup file associations

### DIFF
--- a/App.Library/CommandLineArgumentsHandler.cs
+++ b/App.Library/CommandLineArgumentsHandler.cs
@@ -5,7 +5,6 @@ using Microsoft.Toolkit.Uwp.Notifications;
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
@@ -20,81 +19,78 @@ namespace App.Library
         /// <returns>true if startup is to be aborted</returns>
         public static bool PreGuiCommandLineArgs(string[] args)
         {
-            // shorthand
-            bool contains(string check) =>
-                args.Any(param => string.Equals(param, check, StringComparison.InvariantCultureIgnoreCase));
-
-            if (contains("/?")
-                || contains("/help"))
-            {
-                ShowHelpText();
-
-                return true;
+            if (args.Length == 0) {
+                return false; // continue to app
             }
-            
-            if (contains("/install")) // todo: MessageBox.Show(yes/no)
+            if (args[0][0] != '/')
             {
-                InstallTask.Install();
-
-                return true;
+                Settings.Settings.EapConfigFileLocation = args[0];
+                return false; // continue to app
             }
 
-            if (contains("/install-eap-config"))
+            var force = false;
+            switch (args[0].ToLowerInvariant())
             {
-                if (!string.IsNullOrEmpty(args[1]))
-                {
-                    Settings.Settings.EapConfigFileLocation = args[1];
-                }
-                else
-                {
-                    MessageBox.Show("No argument given for eap-config file location", $"Exception {Settings.Settings.ApplicationIdentifier}");
-                    return true;
-                }
+                case "/?":
+                case "/help":
+                    {
+                        ShowHelpText();
 
-                // continue to app
-                return false;
+                        return true; // terminate after
+                    }
+
+                case "/install":
+                    {
+                        InstallTask.Install();
+
+                        return true; // terminate after
+                    }
+
+                case "/uninstall":
+                    {
+                        UninstallTask.Uninstall(_ => { Environment.Exit(0); });
+
+                        return true; // terminate after
+                    }
+
+                case "/force-refresh":
+                case "/refresh-force":
+                    force = true;
+                    goto case "/refresh";
+                case "/refresh":
+                    {
+                        force |= args.Length >= 2 && string.Equals(args[1], "/force", StringComparison.OrdinalIgnoreCase);
+                        Task.Run(async () => { await RefreshTask.RefreshAsync(force: force); });
+
+                        return true; // terminate after
+                    }
+
+                case "/check-certificate":
+                    {
+                        var st = new StatusTask();
+                        var gst = st.GetStatus();
+                        var diffDate = (gst.ExpirationDate - DateTime.Now).Value.Days;
+
+                        if (diffDate <= Settings.Settings.DaysLeftForNotification)
+                        {
+                            new ToastContentBuilder()
+                                .AddText(string.Format(Resources.CheckCertificateToastP1, Settings.Settings.ApplicationIdentifier))
+                                .AddText(string.Format(Resources.CheckCertificateToastP2, diffDate))
+                                .AddButton(new ToastButton()
+                                    .SetContent(Resources.CheckCertificateToastButton)
+                                    .SetBackgroundActivation()
+                                 )
+                                .Show();
+                        }
+
+                        return true; // terminate after
+                    }
+
+                case "/close":
+                case "/background":
+                    return true; // Deprecated flags, just terminate
             }
-
-            if (contains("/uninstall"))
-            {
-                UninstallTask.Uninstall(_ => { Environment.Exit(0); });
-
-                return true;
-            }
-
-            if (contains("/refresh")
-                || contains("/force-refresh")
-                || contains("/refresh-force"))
-            {
-                Task.Run(async () => { await RefreshTask.RefreshAsync(force: contains("/refresh-force")); });
-
-                return true;
-            }
-
-            if(contains("/check-certificate"))
-            {
-                var st = new StatusTask();
-                var gst = st.GetStatus();
-                var diffDate = (gst.ExpirationDate - DateTime.Now).Value.Days;
-
-                if (diffDate <= Settings.Settings.DaysLeftForNotification)
-                {
-                    new ToastContentBuilder()
-                        .AddText(string.Format(Resources.CheckCertificateToastP1, Settings.Settings.ApplicationIdentifier))
-                        .AddText(string.Format(Resources.CheckCertificateToastP2, diffDate))
-                        .AddButton(new ToastButton()
-                            .SetContent(Resources.CheckCertificateToastButton)
-                            .SetBackgroundActivation()
-                         )
-                        .Show();
-                }
-            
-                return true;
-            }
-
-            return contains("/close")
-                   // Just quit when being started with /background
-                   || contains("/background");
+            return false;
         }
 
         private static void ShowHelpText() =>

--- a/EduRoam.Connect/Install/SelfInstaller.cs
+++ b/EduRoam.Connect/Install/SelfInstaller.cs
@@ -356,6 +356,18 @@ namespace EduRoam.Connect.Install
                     exceptionOnNotExists: false);
             }
 
+            // remove file association
+            var fileRegEapConfig = Registry.CurrentUser.OpenSubKey("Software\\Classes\\.eap-config");
+            if (fileRegEapConfig != null) {
+                var subkey = fileRegEapConfig.OpenSubKey("shell\\open\\command");
+                // If .eap-config is still ours, remove the file association
+                if (string.Equals(subkey?.GetValue(null), $"{this.InstallExePath} \"%1\""))
+                {
+                    Registry.CurrentUser.DeleteSubKeyTree("Software\\Classes\\.eap-config", false);
+                }
+                fileRegEapConfig.Close();
+            }
+
             // remove registry entries
             Debug.WriteLine("Delete registry value: " + rnsRun + "\\" + this.applicationIdentifier);
             using (var key = Registry.CurrentUser

--- a/EduRoam.Connect/Install/SelfInstaller.cs
+++ b/EduRoam.Connect/Install/SelfInstaller.cs
@@ -218,8 +218,11 @@ namespace EduRoam.Connect.Install
                     Registry.SetValue(this.rnsUninstall, key, value);
                 });
 
+            // Add file association
             var fileRegEapConfig = Registry.CurrentUser.CreateSubKey("Software\\Classes\\.eap-config");
             fileRegEapConfig.CreateSubKey("shell\\open\\command").SetValue("", $"{this.InstallExePath} /install-eap-config \"%1\"");
+            // TODO: Use a document icon instead of the same icon as the exe file
+            fileRegEapConfig.CreateSubKey("DefaultIcon").SetValue(null, $"{this.InstallExePath}");
             fileRegEapConfig.Close();
 
             // Add shortcut to start menu

--- a/EduRoam.Connect/Install/SelfInstaller.cs
+++ b/EduRoam.Connect/Install/SelfInstaller.cs
@@ -220,7 +220,7 @@ namespace EduRoam.Connect.Install
 
             // Add file association
             var fileRegEapConfig = Registry.CurrentUser.CreateSubKey("Software\\Classes\\.eap-config");
-            fileRegEapConfig.CreateSubKey("shell\\open\\command").SetValue("", $"{this.InstallExePath} /install-eap-config \"%1\"");
+            fileRegEapConfig.CreateSubKey("shell\\open\\command").SetValue(null, $"{this.InstallExePath} \"%1\"");
             // TODO: Use a document icon instead of the same icon as the exe file
             fileRegEapConfig.CreateSubKey("DefaultIcon").SetValue(null, $"{this.InstallExePath}");
             fileRegEapConfig.Close();

--- a/EduRoam.Connect/Install/SelfInstaller.cs
+++ b/EduRoam.Connect/Install/SelfInstaller.cs
@@ -218,11 +218,6 @@ namespace EduRoam.Connect.Install
                     Registry.SetValue(this.rnsUninstall, key, value);
                 });
 
-            // Create SubKey in Regex for file association (.eap/.eap-config)
-            var fileRegEap = Registry.CurrentUser.CreateSubKey("Software\\Classes\\.eap");
-            fileRegEap.CreateSubKey("shell\\open\\command").SetValue("", $"{this.InstallExePath} /install-eap-config \"%1\"");
-            fileRegEap.Close();
-
             var fileRegEapConfig = Registry.CurrentUser.CreateSubKey("Software\\Classes\\.eap-config");
             fileRegEapConfig.CreateSubKey("shell\\open\\command").SetValue("", $"{this.InstallExePath} /install-eap-config \"%1\"");
             fileRegEapConfig.Close();


### PR DESCRIPTION
Cleans up the file associations.

* Do not associate .eap, only .eap-config
* Remove file association at uninstall
* Set icon to file association (but should have a document icon)
* Remove /install-eap-config flag, just provide the file directly to the executable

As part of this cleanup, the parameter parsing was also changed to use switch/case instead of many if's.  This made it easier to support giving a filename to the program as parameter.