### PR TITLE
Move minimal version check to discovery file

### DIFF
--- a/App.Library/Utility/UpdateChecker.cs
+++ b/App.Library/Utility/UpdateChecker.cs
@@ -24,7 +24,6 @@ public static class UpdateChecker
 
     public static UpdateResponseRootDto UpdateData { get; set; } = new();       
     public static bool IsUpdateAvailable { get; set; }
-    public static SemVersion? MinimalSupportedVersion { get; set; } 
     public static string NewVersion { get; set; }
 
     // http objects
@@ -41,7 +40,6 @@ public static class UpdateChecker
         var newVersion = new SemVersion(parsedVersion.Major, parsedVersion.Minor, parsedVersion.Build);
 
         var parsedMinimalSupportedVersion = Version.Parse(UpdateData.MinimalSupportedVersion);
-        MinimalSupportedVersion = new SemVersion(parsedMinimalSupportedVersion.Major, parsedMinimalSupportedVersion.Minor, parsedMinimalSupportedVersion.Build);
 
         IsUpdateAvailable = SelfInstaller.DefaultInstance.CanBeUpdated(newVersion);
 

--- a/App.Library/ViewModels/MainViewModel.cs
+++ b/App.Library/ViewModels/MainViewModel.cs
@@ -216,24 +216,44 @@ namespace App.Library.ViewModels
                 this.SetStartContent();
             }
 
-
             void OnDenyUnsupported()
             {
                 Application.Current.Shutdown(1);
             }
 
-            if (SemVersion.ComparePrecedence(SelfInstaller.DefaultInstance.GetCurrentVersion(), UpdateChecker.MinimalSupportedVersion) == -1)
+            if (this.idpDownloader.OutdatedAppFailure)
             {
-                this.SetActiveContent(new ConfirmViewModel(this, string.Format(EduRoam.Localization.Resources.VersionNoLongerSupported, Settings.Settings.ApplicationIdentifier, SelfInstaller.DefaultInstance.GetCurrentVersionString(), UpdateChecker.MinimalSupportedVersion, UpdateChecker.NewVersion), confirmOnly: false, OnConfirmUpdate, OnDenyUnsupported));
+                this.SetActiveContent(new ConfirmViewModel(
+                    this, 
+                    string.Format(
+                        EduRoam.Localization.Resources.VersionNoLongerSupported, 
+                        Settings.Settings.ApplicationIdentifier, 
+                        Settings.Settings.ApplicationVersion, 
+                        this.idpDownloader.MinimalAppVersion?.ToString() ?? "Unsupported", 
+                        UpdateChecker.NewVersion
+                    ), 
+                    confirmOnly: false, 
+                    OnConfirmUpdate, 
+                    OnDenyUnsupported
+                ));
 
                 return;
             }
 
             if (UpdateChecker.IsUpdateAvailable)
             {
-                this.SetActiveContent(new ConfirmViewModel(this, string.Format(EduRoam.Localization.Resources.UpdateAvailableMessage, Settings.Settings.ApplicationIdentifier, SelfInstaller.DefaultInstance.GetCurrentVersionString(), UpdateChecker.NewVersion), confirmOnly: false, OnConfirmUpdate, OnDenyUpdate));
-
-
+                this.SetActiveContent(new ConfirmViewModel(
+                    this, 
+                    string.Format(
+                        EduRoam.Localization.Resources.UpdateAvailableMessage, 
+                        Settings.Settings.ApplicationIdentifier, 
+                        Settings.Settings.ApplicationVersion, 
+                        UpdateChecker.NewVersion
+                    ), 
+                    confirmOnly: false, 
+                    OnConfirmUpdate, 
+                    OnDenyUpdate
+                ));
 
                 return;
             }

--- a/App.Settings/App.Settings.csproj
+++ b/App.Settings/App.Settings.csproj
@@ -4,4 +4,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
+	<ItemGroup>
+	  <PackageReference Include="Semver" Version="2.3.0" />
+	</ItemGroup>
 </Project>

--- a/App.Settings/Settings.cs
+++ b/App.Settings/Settings.cs
@@ -1,4 +1,9 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
+using System.Diagnostics;
+using System.Reflection;
+
+using Semver;
 
 namespace App.Settings
 {
@@ -9,5 +14,21 @@ namespace App.Settings
         public static string UpdateBaseUrl { get; set; } = "https://dl.eduroam.app";
         public static int DaysLeftForNotification { get; set; } = 10;
         public static string? EapConfigFileLocation { get; set; } = null;
+        public static SemVersion ApplicationVersion { get; } = GetApplicationVersion();
+
+        private static SemVersion GetApplicationVersion()
+        {
+            return GetFileVersion(Assembly.GetEntryAssembly().Location);
+        }
+
+        public static SemVersion GetFileVersion(string path)
+        {
+            var fileVersion = FileVersionInfo.GetVersionInfo(path);
+            var v = fileVersion.FileVersion;
+            var splittedVersion = v.Split(".".ToCharArray());
+
+
+            return new SemVersion(int.Parse(splittedVersion[0]), int.Parse(splittedVersion[1]), int.Parse(splittedVersion[2]));
+        }
     }
 }

--- a/EduRoam.Connect/Identity/IdentityProviderDownloader.cs
+++ b/EduRoam.Connect/Identity/IdentityProviderDownloader.cs
@@ -21,6 +21,8 @@ using System.Management;
 
 using EduRoam.Connect.Converter;
 using EduRoam.Connect.Identity.v2;
+using Semver;
+using System.Reflection;
 
 namespace EduRoam.Connect.Identity
 {
@@ -49,6 +51,9 @@ namespace EduRoam.Connect.Identity
         }
 
         public bool Loaded { get => this.Providers.Any(); }
+
+        public bool OutdatedAppFailure { get; private set; } = false; // Changes to true if discovery shows we are outdated
+        public SemVersion MinimalAppVersion { get; private set; }
 
         private static HttpClient InitializeHttpClient()
         {
@@ -134,8 +139,21 @@ namespace EduRoam.Connect.Identity
 
                     if (isNewVersion)
                     {
-                        var discovery = JsonConvert.DeserializeObject<LetsWifiDiscovery>(apiJson);
-                        discoveryData = DiscoveryConverter.Covert(discovery ?? new LetsWifiDiscovery());
+                        var discovery = JsonConvert.DeserializeObject<LetsWifiDiscovery>(apiJson) ?? new LetsWifiDiscovery();
+                        SemVersion? minimalVersion = null;
+                        discovery.Root.MinimalAppVersion.TryGetValue(Settings.OAuthClientId, out minimalVersion);
+                        this.MinimalAppVersion = minimalVersion;
+                        if (minimalVersion == null || SemVersion.ComparePrecedence(Settings.ApplicationVersion, minimalVersion) == -1)
+                        {
+                            // We are too old, remove downloaded discovery
+                            discovery = new LetsWifiDiscovery();
+                            discoveryData = new DiscoveryApi();
+                            this.OutdatedAppFailure = true;
+                        }
+                        else
+                        {
+                            discoveryData = DiscoveryConverter.Covert(discovery);
+                        }
                     }
                     else
                     {

--- a/EduRoam.Connect/Identity/v2/LetsWifiDiscovery.cs
+++ b/EduRoam.Connect/Identity/v2/LetsWifiDiscovery.cs
@@ -2,6 +2,8 @@
 
 using Newtonsoft.Json;
 
+using Semver;
+
 namespace EduRoam.Connect.Identity.v2
 {
     public class LetsWifiDiscovery
@@ -12,6 +14,7 @@ namespace EduRoam.Connect.Identity.v2
         public class DiscoveryRoot
         {
             public List<DiscoveryInstitution> Providers { get; set; } = new();
+            public Dictionary<string, SemVersion> MinimalAppVersion = new();
             public string Seq { get; set; } = null!;
         }
         

--- a/EduRoam.Connect/Install/SelfInstaller.cs
+++ b/EduRoam.Connect/Install/SelfInstaller.cs
@@ -420,13 +420,7 @@ namespace EduRoam.Connect.Install
         /// <summary>
         /// For AutoInstaller, location is Install Path
         /// </summary>
-        public bool CanBeUpdated()
-        {
-            var installedVersion = this.GetFileVersion(this.InstallExePath);
-            var runningVersion = this.GetFileVersion(System.Reflection.Assembly.GetEntryAssembly()!.Location);
-
-            return (SemVersion.ComparePrecedence(installedVersion, runningVersion) == -1);
-        }
+        public bool CanBeUpdated() => this.CanBeUpdated(Settings.GetFileVersion(this.InstallExePath));
 
         /// <summary>
         /// For UpdateChecker, location is Current path
@@ -435,7 +429,7 @@ namespace EduRoam.Connect.Install
         /// <returns></returns>
         public bool CanBeUpdated(SemVersion newVersion)
         {
-            var installedVersion = this.GetCurrentVersion();
+            var installedVersion = Settings.ApplicationVersion;
             return (SemVersion.ComparePrecedence(installedVersion, newVersion) == -1);
         }
 
@@ -468,19 +462,6 @@ namespace EduRoam.Connect.Install
         {
             Process.Start(this.InstallExePath);
         }
-
-        private SemVersion GetFileVersion(string path)
-        {
-            var fileVersion = FileVersionInfo.GetVersionInfo(path);
-            var v = fileVersion.FileVersion;
-            var splittedVersion = v.Split(".".ToCharArray());
-
-
-            return new SemVersion(int.Parse(splittedVersion[0]), int.Parse(splittedVersion[1]), int.Parse(splittedVersion[2]));
-        }
-
-        public SemVersion GetCurrentVersion() => this.GetFileVersion(ThisExePath);
-        public string GetCurrentVersionString() => this.GetCurrentVersion().ToString();
         #endregion
     }
 


### PR DESCRIPTION
Removes `MinimalSupportedVersion` from update.json and check the minimal supported version from within discovery.json instead.

The minimal supported version only affects whether the discovery can be used, so it makes more sense to check it there.  The update check and the process for downloading a new binary and installing it is not changed, and not intended to be changed.

This change opens the way to make the update.json checking process async, to be done while the UI is already visible.

In order to make this change, some code had to be moved around. The update code did some calls to the SelfInstaller class to find out the current version number. I moved this code to Settings; that made more sense because it also contains the OAuth client ID and the application name. More things can (and probably should) be moved there, but in this PR I only moved what was necessary for this to work.