### PR TITLE
Add support for fingerprint server verification

### DIFF
--- a/EduRoam.Connect/Eap/AuthenticationMethod.cs
+++ b/EduRoam.Connect/Eap/AuthenticationMethod.cs
@@ -21,9 +21,9 @@ namespace EduRoam.Connect.Eap
         public EapConfig? EapConfig { get; } // reference to parent EapConfig
         public EapType EapType { get; }
         public InnerAuthType InnerAuthType { get; }
-        public List<string> ServerCertificateAuthorities { get; } // base64 encoded DER certificate
-        public List<string> CertificateThumbprints { get; }
-        public List<string> ServerNames { get; }
+        public ICollection<(string Type, string B64)> ServerCertificateAuthorities { get; } // type, base64 encoded DER certificate
+        public ICollection<(string ReplaceType, string HEX)> CertificateThumbprints { get; } // CA type to replace, HEX thumbprint
+        public ICollection<string> ServerNames { get; }
         public string? ClientUserName { get; } // preset inner identity, expect it to have a realm
         public string? ClientPassword { get; } // preset outer identity
         public string? ClientCertificate { get; } // base64 encoded PKCS12 certificate+privkey bundle
@@ -95,15 +95,21 @@ namespace EduRoam.Connect.Eap
         /// <remarks>The certificates must be disposed after use</remarks>
         public IEnumerable<X509Certificate2> CertificateAuthoritiesAsX509Certificate2()
         {
-            if (this.CertificateThumbprints.Count != 0) yield break;
+            var removeTypes = new HashSet<string>();
+            foreach (var thumbprint in CertificateThumbprints)
+            {
+                removeTypes.Add(thumbprint.ReplaceType);
+            }
 
             foreach (var ca in this.ServerCertificateAuthorities)
             {
+                if (!string.IsNullOrEmpty(ca.Type) && removeTypes.Contains(ca.Type)) continue;
+
                 X509Certificate2 cert;
                 try
                 {
                     // TODO: find some nice way to ensure these are disposed of properly
-                    cert = new X509Certificate2(Convert.FromBase64String(ca));
+                    cert = new X509Certificate2(Convert.FromBase64String(ca.B64));
                 }
                 catch (CryptographicException)
                 {
@@ -344,9 +350,9 @@ namespace EduRoam.Connect.Eap
         internal AuthenticationMethod(
             EapType eapType,
             InnerAuthType innerAuthType,
-            List<string> serverCertificateAuthorities,
-            List<string> serverName,
-            List<string> certificateThumbprints = null,
+            ICollection<(string,string)> serverCertificateAuthorities,
+            ICollection<string> serverName,
+            ICollection<(string,string)> certificateThumbprints = null,
             string? clientUserName = null,
             string? clientPassword = null,
             string? clientCertificate = null,
@@ -354,15 +360,29 @@ namespace EduRoam.Connect.Eap
             string? clientOuterIdentity = null,
             string? innerIdentitySuffix = null,
             bool innerIdentityHint = false
-        ) : this(null, eapType, innerAuthType, serverCertificateAuthorities, serverName, certificateThumbprints, clientUserName, clientPassword, clientCertificate, clientCertificatePassphrase, clientOuterIdentity, innerIdentitySuffix, innerIdentityHint) { }
+        ) : this(
+            null, 
+            eapType, 
+            innerAuthType, 
+            serverCertificateAuthorities, 
+            serverName, 
+            certificateThumbprints, 
+            clientUserName, 
+            clientPassword, 
+            clientCertificate, 
+            clientCertificatePassphrase, 
+            clientOuterIdentity, 
+            innerIdentitySuffix, 
+            innerIdentityHint
+        ) { }
 
         private AuthenticationMethod(
             EapConfig? eapConfig,
             EapType eapType,
             InnerAuthType innerAuthType,
-            List<string> serverCertificateAuthorities,
-            List<string> serverName,
-            List<string> certificateThumbprints = null,
+            ICollection<(string,string)> serverCertificateAuthorities,
+            ICollection<string> serverName,
+            ICollection<(string,string)> certificateThumbprints = null,
             string? clientUserName = null,
             string? clientPassword = null,
             string? clientCertificate = null,
@@ -375,9 +395,9 @@ namespace EduRoam.Connect.Eap
             this.EapConfig = eapConfig;
             this.EapType = eapType;
             this.InnerAuthType = innerAuthType;
-            this.ServerCertificateAuthorities = serverCertificateAuthorities ?? new List<string>();
-            this.CertificateThumbprints = certificateThumbprints ?? new List<string>();
-            this.ServerNames = serverName ?? new List<string>();
+            this.ServerCertificateAuthorities = serverCertificateAuthorities ?? new HashSet<(string,string)>();
+            this.ServerNames = serverName ?? new HashSet<string>();
+            this.CertificateThumbprints = certificateThumbprints ?? new HashSet<(string, string)>();
             this.ClientUserName = clientUserName;
             this.ClientPassword = clientPassword;
             this.ClientCertificate = clientCertificate;

--- a/EduRoam.Connect/Eap/AuthenticationMethod.cs
+++ b/EduRoam.Connect/Eap/AuthenticationMethod.cs
@@ -22,6 +22,7 @@ namespace EduRoam.Connect.Eap
         public EapType EapType { get; }
         public InnerAuthType InnerAuthType { get; }
         public List<string> ServerCertificateAuthorities { get; } // base64 encoded DER certificate
+        public List<string> CertificateThumbprints { get; }
         public List<string> ServerNames { get; }
         public string? ClientUserName { get; } // preset inner identity, expect it to have a realm
         public string? ClientPassword { get; } // preset outer identity
@@ -94,6 +95,8 @@ namespace EduRoam.Connect.Eap
         /// <remarks>The certificates must be disposed after use</remarks>
         public IEnumerable<X509Certificate2> CertificateAuthoritiesAsX509Certificate2()
         {
+            if (this.CertificateThumbprints.Count != 0) yield break;
+
             foreach (var ca in this.ServerCertificateAuthorities)
             {
                 X509Certificate2 cert;
@@ -212,6 +215,7 @@ namespace EduRoam.Connect.Eap
                     this.InnerAuthType,
                     this.ServerCertificateAuthorities,
                     this.ServerNames,
+                    this.CertificateThumbprints,
                     username,
                     password,
                     this.ClientCertificate,
@@ -233,6 +237,7 @@ namespace EduRoam.Connect.Eap
                     this.InnerAuthType,
                     this.ServerCertificateAuthorities,
                     this.ServerNames,
+                    this.CertificateThumbprints,
                     this.ClientUserName,
                     this.ClientPassword,
                     Convert.ToBase64String(File.ReadAllBytes(filePath)),
@@ -256,6 +261,7 @@ namespace EduRoam.Connect.Eap
                     this.InnerAuthType,
                     this.ServerCertificateAuthorities,
                     this.ServerNames,
+                    this.CertificateThumbprints,
                     this.ClientUserName,
                     this.ClientPassword,
                     this.ClientCertificate,
@@ -272,6 +278,7 @@ namespace EduRoam.Connect.Eap
                     this.InnerAuthType,
                     this.ServerCertificateAuthorities,
                     this.ServerNames,
+                    this.CertificateThumbprints,
                     this.ClientUserName,
                     this.ClientPassword,
                     this.ClientCertificate,
@@ -339,6 +346,7 @@ namespace EduRoam.Connect.Eap
             InnerAuthType innerAuthType,
             List<string> serverCertificateAuthorities,
             List<string> serverName,
+            List<string> certificateThumbprints = null,
             string? clientUserName = null,
             string? clientPassword = null,
             string? clientCertificate = null,
@@ -346,7 +354,7 @@ namespace EduRoam.Connect.Eap
             string? clientOuterIdentity = null,
             string? innerIdentitySuffix = null,
             bool innerIdentityHint = false
-        ) : this(null, eapType, innerAuthType, serverCertificateAuthorities, serverName, clientUserName, clientPassword, clientCertificate, clientCertificatePassphrase, clientOuterIdentity, innerIdentitySuffix, innerIdentityHint) { }
+        ) : this(null, eapType, innerAuthType, serverCertificateAuthorities, serverName, certificateThumbprints, clientUserName, clientPassword, clientCertificate, clientCertificatePassphrase, clientOuterIdentity, innerIdentitySuffix, innerIdentityHint) { }
 
         private AuthenticationMethod(
             EapConfig? eapConfig,
@@ -354,6 +362,7 @@ namespace EduRoam.Connect.Eap
             InnerAuthType innerAuthType,
             List<string> serverCertificateAuthorities,
             List<string> serverName,
+            List<string> certificateThumbprints = null,
             string? clientUserName = null,
             string? clientPassword = null,
             string? clientCertificate = null,
@@ -367,6 +376,7 @@ namespace EduRoam.Connect.Eap
             this.EapType = eapType;
             this.InnerAuthType = innerAuthType;
             this.ServerCertificateAuthorities = serverCertificateAuthorities ?? new List<string>();
+            this.CertificateThumbprints = certificateThumbprints ?? new List<string>();
             this.ServerNames = serverName ?? new List<string>();
             this.ClientUserName = clientUserName;
             this.ClientPassword = clientPassword;

--- a/EduRoam.Connect/Eap/EapConfig.cs
+++ b/EduRoam.Connect/Eap/EapConfig.cs
@@ -105,18 +105,16 @@ namespace EduRoam.Connect.Eap
 
                 // ServerSideCredential
 
-                var serverFingerprints = authMethodXml
-                    .Elements().First(nameIs("EAPMethod"))
-                    .Elements().Where(nameIs("VendorSpecific")).First(xElement => xElement.Attribute("vendor").Value == "1023")
-                    .Elements().FirstOrDefault(nameIs("ServerSideCredential"))?
+                // get list of fingerprints and the CAs they will replace
+                var serverFingerprints = serverSideCredentialXml?
                     .Elements().Where(nameIs("Fingerprint"))
-                    .Select(xElement => (string)xElement)
+                    .Select(xElement => ((string)xElement.Attribute("replace")?.Value, (string)xElement))
                     .ToList();
 
-                // get list of strings of CA certificates
+                // get list of strings of CA certificates and the type, which is a selector for replacement
                 var serverCAs = serverSideCredentialXml?
                     .Elements().Where(nameIs("CA")) // TODO: <CA format="X.509" encoding="base64"> is assumed, schema does not enforce this
-                    .Select(xElement => (string)xElement)
+                    .Select(xElement => ((string)xElement.Attribute("type")?.Value, (string)xElement))
                     .ToList();
 
                 // get list of strings of server IDs
@@ -149,9 +147,9 @@ namespace EduRoam.Connect.Eap
                 authMethods.Add(new AuthenticationMethod(
                     eapType,
                     innerAuthType,
-                    serverCAs ?? new List<string>(),
+                    serverCAs ?? new List<(string,string)>(),
                     serverNames ?? new List<string>(),
-                    serverFingerprints ?? new List<string>(),
+                    serverFingerprints ?? new List<(string,string)>(),
                     clientUserName,
                     clientPassword,
                     clientCert,

--- a/EduRoam.Connect/Eap/EapConfig.cs
+++ b/EduRoam.Connect/Eap/EapConfig.cs
@@ -105,6 +105,14 @@ namespace EduRoam.Connect.Eap
 
                 // ServerSideCredential
 
+                var serverFingerprints = authMethodXml
+                    .Elements().First(nameIs("EAPMethod"))
+                    .Elements().Where(nameIs("VendorSpecific")).First(xElement => xElement.Attribute("vendor").Value == "1023")
+                    .Elements().FirstOrDefault(nameIs("ServerSideCredential"))?
+                    .Elements().Where(nameIs("Fingerprint"))
+                    .Select(xElement => (string)xElement)
+                    .ToList();
+
                 // get list of strings of CA certificates
                 var serverCAs = serverSideCredentialXml?
                     .Elements().Where(nameIs("CA")) // TODO: <CA format="X.509" encoding="base64"> is assumed, schema does not enforce this
@@ -143,6 +151,7 @@ namespace EduRoam.Connect.Eap
                     innerAuthType,
                     serverCAs ?? new List<string>(),
                     serverNames ?? new List<string>(),
+                    serverFingerprints ?? new List<string>(),
                     clientUserName,
                     clientPassword,
                     clientCert,

--- a/EduRoam.Connect/Extensions.cs
+++ b/EduRoam.Connect/Extensions.cs
@@ -14,7 +14,7 @@ namespace EduRoam.Connect
         // lower case with a space after every hexit, including the last one
         // Formatting it this way does not seem necessary for the profile to work,
         // but we do so anyway in order to minimize potential problems
-        public static string ToHexString(this string thumb)
+        public static string FormatHexString(this string thumb)
         {
             var value = Regex.Replace(thumb, " ", "");
             value = Regex.Replace(value, ".{2}", "$0 ");

--- a/EduRoam.Connect/ProfileXml.cs
+++ b/EduRoam.Connect/ProfileXml.cs
@@ -167,7 +167,9 @@ namespace EduRoam.Connect
                                         serverNames: authMethod.ServerNames,
                                         caThumbprints: authMethod.CertificateAuthoritiesAsX509Certificate2()
                                             .Where(cert => cert.Subject == cert.Issuer)
-                                            .Select(cert => cert.Thumbprint).Union(authMethod.CertificateThumbprints).ToList()
+                                            .Select(cert => cert.Thumbprint)
+                                            .Union(authMethod.CertificateThumbprints.Select(cert => cert.HEX))
+                                            .ToList()
                                     )
                                 )
                             )
@@ -223,8 +225,8 @@ namespace EduRoam.Connect
             EapType eapType,
             InnerAuthType innerAuthType,
             string? outerIdentity,
-            List<string> serverNames,
-            List<string> caThumbprints)
+            IEnumerable<string> serverNames,
+            IEnumerable<string> caThumbprints)
         {
             // creates the root xml strucure, with references to some of its descendants
             XElement configElement;
@@ -385,7 +387,7 @@ namespace EduRoam.Connect
         /// <param name="ns">The namespace for this server validation element; this depends on the authentication method, valid values are currently nsETCPv1, nsMPCPv1 and nsTTLS</param>
         /// <param name="serverNames">List of server names, at least one of these must match the CN or subjectAltName of the certificate from the RADIUS server</param>
         /// <param name="caThumbprints">List of trusted CA thumbprints; the server certificate must be signed by one of these roots</param>
-        private static XElement GetServerValidationElement(XNamespace ns, List<string> serverNames, List<string> caThumbprints)
+        private static XElement GetServerValidationElement(XNamespace ns, IEnumerable<string> serverNames, IEnumerable<string> caThumbprints)
         {
             // Windows uses different XML namespaces for different authentication methods,
             // and they are not completely consistent with naming across these different namespaces
@@ -396,8 +398,9 @@ namespace EduRoam.Connect
                 new XElement(ns + disablePromptNodeName, "true"),
                 new XElement(ns + "ServerNames", string.Join(";", serverNames))
             );
-            caThumbprints.ForEach(thumb =>
-                serverValidationElement.Add(new XElement(ns + thumbprintNodeName, thumb.FormatHexString())));
+            foreach (var thumb in caThumbprints) {
+                serverValidationElement.Add(new XElement(ns + thumbprintNodeName, thumb.FormatHexString()));
+            }
 
             return serverValidationElement;
         }

--- a/EduRoam.Connect/ProfileXml.cs
+++ b/EduRoam.Connect/ProfileXml.cs
@@ -167,7 +167,7 @@ namespace EduRoam.Connect
                                         serverNames: authMethod.ServerNames,
                                         caThumbprints: authMethod.CertificateAuthoritiesAsX509Certificate2()
                                             .Where(cert => cert.Subject == cert.Issuer)
-                                            .Select(cert => cert.Thumbprint).ToList()
+                                            .Select(cert => cert.Thumbprint).Union(authMethod.CertificateThumbprints).ToList()
                                     )
                                 )
                             )
@@ -397,7 +397,7 @@ namespace EduRoam.Connect
                 new XElement(ns + "ServerNames", string.Join(";", serverNames))
             );
             caThumbprints.ForEach(thumb =>
-                serverValidationElement.Add(new XElement(ns + thumbprintNodeName, thumb.ToHexString())));
+                serverValidationElement.Add(new XElement(ns + thumbprintNodeName, thumb.FormatHexString())));
 
             return serverValidationElement;
         }

--- a/EduRoam.Connect/UserDataXml.cs
+++ b/EduRoam.Connect/UserDataXml.cs
@@ -128,7 +128,7 @@ namespace EduRoam.Connect
                         new XElement(nsBEUP + "Type", (int)EapType.TLS),
                         new XElement(nsTLS + "EapType",
                             new XElement(nsTLS + "Username", outerIdentity), // TODO: test if this gets used
-                            new XElement(nsTLS + "UserCert", userCertFingerprint?.ToHexString())
+                            new XElement(nsTLS + "UserCert", userCertFingerprint?.FormatHexString())
                         )
                     ),
 


### PR DESCRIPTION
Adds support for Windows-specific server fingerprint, instead of installing a CA.

When fingerprints are provided this way (more than one can be provided), no CA fingerprints are installed and no CA is attempted to be installed in the system.

Not tested for regressions.