### PR TITLE
Fix the notification to reauthentication flow

### DIFF
--- a/App.Library/CommandLineArgumentsHandler.cs
+++ b/App.Library/CommandLineArgumentsHandler.cs
@@ -19,10 +19,16 @@ namespace App.Library
         /// <returns>true if startup is to be aborted</returns>
         public static bool PreGuiCommandLineArgs(string[] args)
         {
-            if (args.Length == 0) {
+            if (args.Length == 0 || (args.Length == 2 && "-ToastActivated -Embedding".Equals(String.Join(" ", args)))) {
+                // When the Toast button is pressed, we get these arguments
+                // If we actually want to have different kinds of Toast buttons,
+                // we should do something smarter here, but for now the button just launches the app.
+
                 return false; // continue to app
             }
-            if (args[0][0] != '/')
+            // We use / flags, and Toast uses -ToastActivated -Embedding
+            // So probably best to not assume that an argument starting with - is a file name
+            if (args[0][0] != '/' && args[0][0] != '-')
             {
                 Settings.Settings.EapConfigFileLocation = args[0];
                 return false; // continue to app
@@ -120,10 +126,9 @@ namespace App.Library
                 new ToastContentBuilder()
                     .AddText(string.Format(Resources.CheckCertificateToastP1, Settings.Settings.ApplicationName))
                     .AddText(string.Format(Resources.CheckCertificateToastP2, diffDate))
-                    .AddButton(new ToastButton()
-                        .SetContent(Resources.CheckCertificateToastButton)
-                        .SetBackgroundActivation()
-                     )
+                    .AddButton(new ToastButton() { ActivationType = ToastActivationType.Foreground }
+                        .SetContent(Resources.CheckCertificateToastButton)                        
+                    )
                     .Show();
             }
         }

--- a/App.Library/CommandLineArgumentsHandler.cs
+++ b/App.Library/CommandLineArgumentsHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Toolkit.Uwp.Notifications;
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace App.Library
@@ -17,7 +18,7 @@ namespace App.Library
         /// Handles command line args not related to wpf behaviour
         /// </summary>
         /// <returns>true if startup is to be aborted</returns>
-        public static bool PreGuiCommandLineArgs(string[] args)
+        public static async Task<bool> PreGuiCommandLineArgs(string[] args)
         {
             if (args.Length == 0 || (args.Length == 2 && "-ToastActivated -Embedding".Equals(String.Join(" ", args)))) {
                 // When the Toast button is pressed, we get these arguments
@@ -95,7 +96,7 @@ namespace App.Library
             {
                 case "/install": InstallTask.Install(verbose ?? false); return true;
                 case "/uninstall": UninstallTask.Uninstall(verbose ?? true); return true;
-                case "/refresh": RefreshCertificate(force, verbose ?? false); return true;
+                case "/refresh": return await RefreshCertificate(force, verbose ?? false);
                 case "/certificate-notify": CertificateToast(force || (verbose ?? false)); return true;
                 case "/close": return true;
                 case "/help":
@@ -106,13 +107,11 @@ namespace App.Library
             }
         }
 
-        private async static void RefreshCertificate(bool force, bool verbose)
+        private async static Task<bool> RefreshCertificate(bool force, bool verbose)
         {
             var expiration = await RefreshTask.RefreshAsync(force: force);
 
-            if (verbose) {
-                MessageBox.Show(string.IsNullOrWhiteSpace(expiration) ? "The certificate was not renewed" : expiration);
-            }
+            return !verbose || string.IsNullOrWhiteSpace(expiration);
         }
 
         private static void CertificateToast(bool verbose)

--- a/App.Library/CommandLineArgumentsHandler.cs
+++ b/App.Library/CommandLineArgumentsHandler.cs
@@ -7,7 +7,6 @@ using Microsoft.Toolkit.Uwp.Notifications;
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace App.Library
@@ -101,13 +100,12 @@ namespace App.Library
             }
         }
 
-        private static void RefreshCertificate(bool force, bool verbose)
+        private async static void RefreshCertificate(bool force, bool verbose)
         {
-            var expiration = Task.Run(async () => { return await RefreshTask.RefreshAsync(force: force); });
-            expiration.RunSynchronously();
+            var expiration = await RefreshTask.RefreshAsync(force: force);
 
             if (verbose) {
-                MessageBox.Show(string.IsNullOrWhiteSpace(expiration.Result) ? expiration.Result : "The certificate was not renewed");
+                MessageBox.Show(string.IsNullOrWhiteSpace(expiration) ? "The certificate was not renewed" : expiration);
             }
         }
 

--- a/App.Library/ViewModels/MainViewModel.cs
+++ b/App.Library/ViewModels/MainViewModel.cs
@@ -521,12 +521,16 @@ namespace App.Library.ViewModels
             get => ArchitectureHelper.ProcessIsNative() && this.status.ActiveProfile;
         }
 
-        public async Task RefreshAsync()
+        public async Task<bool> RefreshAsync()
         {
             if (this.status.ActiveProfile)
             {
-                await RefreshTask.RefreshAsync(true);
+                // On success, RefreshAsync returns expiry info as a string
+                // On failure, empty string
+                // In order not to trigger a rate limit on the server, we have force off here
+                return !string.IsNullOrEmpty(await RefreshTask.RefreshAsync(force: false));
             }
+            return false;
         }
 
         public bool IsReauthenticatePossible

--- a/App.Library/ViewModels/StatusViewModel.cs
+++ b/App.Library/ViewModels/StatusViewModel.cs
@@ -76,8 +76,8 @@ namespace App.Library.ViewModels
         
         private async void Reauthenticate()
         {
+            // TODO: This probably doesn't try the refresh token
             await IdentityProviderDownloader.Instance.LoadProviders();
-            this.Owner.RemoveCertificates();
             this.Owner.Reauthenticate();
         }
     }

--- a/App.Library/ViewModels/StatusViewModel.cs
+++ b/App.Library/ViewModels/StatusViewModel.cs
@@ -11,13 +11,14 @@ namespace App.Library.ViewModels
 {
     internal class StatusViewModel : BaseViewModel
     {
-        private readonly Status status;
+        private readonly StatusTask statusTask;
+        private Status status => this.statusTask.GetStatus();
 
         public StatusViewModel(MainViewModel owner) : base(owner)
         {
             this.SelectOtherInstitutionCommand = new DelegateCommand(this.SelectOtherInstitution, () => true);
             this.RenewAccountCommand = new DelegateCommand(this.Reauthenticate, () => true);
-            this.status = new StatusTask().GetStatus();
+            this.statusTask = new StatusTask();
         }
 
         public override string PageTitle => this.ShowProfileStatus ? this.ProfileName : string.Empty;
@@ -76,9 +77,26 @@ namespace App.Library.ViewModels
         
         private async void Reauthenticate()
         {
-            // TODO: This probably doesn't try the refresh token
-            await IdentityProviderDownloader.Instance.LoadProviders();
-            this.Owner.Reauthenticate();
+            if (await this.Owner.RefreshAsync())
+            {
+                CallPropertyChanged(nameof(ShowTimeLeft));
+                CallPropertyChanged(nameof(TimeLeft));
+                CallPropertyChanged(nameof(ShowRepairButton));
+                CallPropertyChanged(nameof(ShowRenewButton));
+            }
+            else {
+                // RefreshAsync runs without user interaction,
+                // so if new server certificates must be installed,
+                // we end up here.
+                //
+                // TODO: This probably doesn't try the refresh token
+                // TODO: If we do support refresh token, don't use it unless certificate is about to expire,
+                //  as to not trigger rate limit on the server
+                await IdentityProviderDownloader.Instance.LoadProviders();
+                this.Owner.Reauthenticate();
+                // At the end of this, we will have moved to another view,
+                // so we don't need to notify anyone about any changes
+            }
         }
     }
 }

--- a/Eduroam.App/App.xaml.cs
+++ b/Eduroam.App/App.xaml.cs
@@ -48,6 +48,7 @@ namespace Eduroam.App
 
             var mainWindow = this.serviceProvider.GetService<MainWindow>();
             mainWindow.Show();
+            mainWindow.Activate();
         }
     }
 }

--- a/Eduroam.App/App.xaml.cs
+++ b/Eduroam.App/App.xaml.cs
@@ -17,7 +17,7 @@ namespace Eduroam.App
     {
         private ServiceProvider serviceProvider;
 
-        private void App_OnStartup(object sender, StartupEventArgs e)
+        private async void App_OnStartup(object sender, StartupEventArgs e)
         {
             LanguageResources.Culture = System.Globalization.CultureInfo.CurrentUICulture;
             Settings.OAuthClientId = "app.geteduroam.win";
@@ -28,7 +28,7 @@ namespace Eduroam.App
             Settings.BrowserDownloadUrl = "https://www.eduroam.app/";
             Settings.DiscoveryUrl = "https://discovery.eduroam.app/v3/discovery.json";
 
-            if (CommandLineArgumentsHandler.PreGuiCommandLineArgs(e.Args))
+            if (await CommandLineArgumentsHandler.PreGuiCommandLineArgs(e.Args))
             {
                 this.Shutdown(1);
                 return;

--- a/Eduroam.App/Properties/AssemblyInfo.cs
+++ b/Eduroam.App/Properties/AssemblyInfo.cs
@@ -47,6 +47,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.5")]
-[assembly: AssemblyFileVersion("4.2.5")]
+[assembly: AssemblyVersion("4.2.6")]
+[assembly: AssemblyFileVersion("4.2.6")]
 [assembly: AssemblyMetadata("Keywords", "geteduroam, eduroam")]

--- a/Govroam.App/App.xaml.cs
+++ b/Govroam.App/App.xaml.cs
@@ -17,7 +17,7 @@ namespace Govroam.App
     {
         private ServiceProvider serviceProvider;
 
-        private void App_OnStartup(object sender, StartupEventArgs e)
+        private async void App_OnStartup(object sender, StartupEventArgs e)
         {
             LanguageResources.Culture = System.Globalization.CultureInfo.CurrentUICulture;
             Settings.OAuthClientId = "app.getgovroam.win";
@@ -28,7 +28,7 @@ namespace Govroam.App
             Settings.BrowserDownloadUrl = "https://www.govroam.app/";
             Settings.DiscoveryUrl = "https://getgovroam.nl/v3/discovery.json";
 
-            if (CommandLineArgumentsHandler.PreGuiCommandLineArgs(e.Args))
+            if (await CommandLineArgumentsHandler.PreGuiCommandLineArgs(e.Args))
             {
                 this.Shutdown(1);
                 return;

--- a/Govroam.App/App.xaml.cs
+++ b/Govroam.App/App.xaml.cs
@@ -48,6 +48,7 @@ namespace Govroam.App
 
             var mainWindow = this.serviceProvider.GetService<MainWindow>();
             mainWindow.Show();
+            mainWindow.Activate();
         }
     }
 }

--- a/Govroam.App/Properties/AssemblyInfo.cs
+++ b/Govroam.App/Properties/AssemblyInfo.cs
@@ -47,6 +47,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.5")]
-[assembly: AssemblyFileVersion("4.2.5")]
+[assembly: AssemblyVersion("4.2.6")]
+[assembly: AssemblyFileVersion("4.2.6")]
 [assembly: AssemblyMetadata("Keywords", "getgovroam, govroam")]


### PR DESCRIPTION
When the credential did not renew automatically, the user is presented a notification. This pull request reworks how this notification and account refresh is being handled.

This PR contains the following notable changes for the OAuth flow:
- Pressing the notification button will now reliably open the app
- Pressing the "Repair account" or the "Renew account" button will first attempt a non-forced refresh using the refresh token, if that fails, a new login flow is started automatically